### PR TITLE
WindowManager [ DrawColourBlock]

### DIFF
--- a/Source/ConsoleDraw/WindowManager.cs
+++ b/Source/ConsoleDraw/WindowManager.cs
@@ -9,16 +9,28 @@ namespace ConsoleDraw
 {
     public static class WindowManager
     {
-        public static void DrawColourBlock(ConsoleColor colour, int startX, int startY, int endX, int endY)
-        {
-            Console.BackgroundColor = colour;
 
+        public static void DrawColourBlock(ConsoleColor colour, int startX, int startY, int endX, int endY,bool restoreSetting = true)
+        {
+            ConsoleColor oldcolor = Console.BackgroundColor;
+            int oldX = Console.CursorLeft;
+            int oldy = Console.CursorTop;
+
+            Console.BackgroundColor = colour;
+            
             for (var i = startX; i < endX; i++)
             {
                 Console.CursorLeft = startY;
                 Console.CursorTop = i;
 
                 Console.WriteLine("".PadLeft(endY - startY));
+            }
+
+            if(restoreSetting)
+            {
+                Console.BackgroundColor = oldcolor;
+                Console.CursorLeft = oldX;
+                Console.CursorTop = oldy;
             }
         }
 

--- a/Source/InlineTestApp/Program.cs
+++ b/Source/InlineTestApp/Program.cs
@@ -17,6 +17,9 @@ namespace InlineTestApp
             Console.WriteLine();
             Console.WriteLine();
 
+            WindowManager.DrawColourBlock(ConsoleColor.Red, 15, 20, 20, 25);
+
+
             for (var i = 0; i < 2; i++ )
                 Console.WriteLine(i.ToString());
 


### PR DESCRIPTION
Fixed in WindowManager DrawColourBlock whit optional bool to prevent
user draw next line colored.

When the user calls this method all text after this call all draws whit colored background.